### PR TITLE
set the default timezone as UTC

### DIFF
--- a/src/main/java/it/pagopa/interop/probing/eservice/operations/InteropProbingApplication.java
+++ b/src/main/java/it/pagopa/interop/probing/eservice/operations/InteropProbingApplication.java
@@ -1,13 +1,15 @@
 package it.pagopa.interop.probing.eservice.operations;
 
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class InteropProbingApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(InteropProbingApplication.class, args);
-	}
+  public static void main(String[] args) {
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    SpringApplication.run(InteropProbingApplication.class, args);
+  }
 
 }


### PR DESCRIPTION
By setting the default timezone we are sure that every time and timestamp created (in our case pollingEndTime and pollingStartTime  defaults) have the UTC offset.