### PR TITLE
Merge bugfix/IESP-222

### DIFF
--- a/src/main/java/it/pagopa/interop/probing/eservice/operations/repository/query/builder/EserviceContentQueryBuilder.java
+++ b/src/main/java/it/pagopa/interop/probing/eservice/operations/repository/query/builder/EserviceContentQueryBuilder.java
@@ -10,10 +10,6 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import it.pagopa.interop.probing.eservice.operations.dtos.EserviceContent;
 import it.pagopa.interop.probing.eservice.operations.dtos.EserviceInteropState;
@@ -27,7 +23,7 @@ public class EserviceContentQueryBuilder {
   @PersistenceContext
   private EntityManager entityManager;
 
-  public Page<EserviceContent> findAllEservicesReadyForPolling(Integer limit, Integer offset) {
+  public List<EserviceContent> findAllEservicesReadyForPolling(Integer limit, Integer offset) {
     CriteriaBuilder cb = entityManager.getCriteriaBuilder();
     CriteriaQuery<EserviceContentCriteria> query = cb.createQuery(EserviceContentCriteria.class);
     Root<EserviceView> root = query.from(EserviceView.class);
@@ -36,6 +32,29 @@ public class EserviceContentQueryBuilder {
         root.get(EserviceView_.TECHNOLOGY), root.get(EserviceView_.BASE_PATH),
         root.get(EserviceView_.AUDIENCE));
 
+    Predicate predicate = buildPredicate(cb, root);
+
+    query.where(predicate).orderBy(cb.asc(root.get(EserviceView_.ESERVICE_RECORD_ID)));
+
+    TypedQuery<EserviceContentCriteria> q =
+        entityManager.createQuery(query).setFirstResult(offset).setMaxResults(limit);
+
+    return q.getResultList().stream().map(e -> (EserviceContent) e).toList();
+  }
+
+  public Long getTotalCount() {
+    CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+    CriteriaQuery<Long> criteriaQuery = cb.createQuery(Long.class);
+    Root<EserviceView> root = criteriaQuery.from(EserviceView.class);
+
+    Predicate predicate = buildPredicate(cb, root);
+
+    criteriaQuery.select(cb.count(root.get(EserviceView_.ESERVICE_RECORD_ID))).where(predicate);
+
+    return entityManager.createQuery(criteriaQuery).getSingleResult();
+  }
+
+  private Predicate buildPredicate(CriteriaBuilder cb, Root<EserviceView> root) {
     Expression<Timestamp> makeInterval = cb.function("make_interval", Timestamp.class,
         root.get(EserviceView_.LAST_REQUEST), root.get(EserviceView_.POLLING_FREQUENCY));
 
@@ -43,24 +62,16 @@ public class EserviceContentQueryBuilder {
         cb.function("compare_timestamp_interval", Boolean.TYPE,
             root.get(EserviceView_.POLLING_START_TIME), root.get(EserviceView_.POLLING_END_TIME));
 
-    Predicate predicate =
-        cb.and(cb.equal(root.get(EserviceView_.STATE), EserviceInteropState.ACTIVE),
-            cb.isTrue(root.get(EserviceView_.PROBING_ENABLED)),
-            cb.or(
-                cb.and(cb.isNull(root.get(EserviceView_.LAST_REQUEST)),
-                    cb.isNull(root.get(EserviceView_.RESPONSE_RECEIVED))),
-                cb.and(cb.lessThanOrEqualTo(makeInterval, cb.currentTimestamp()),
-                    cb.lessThanOrEqualTo(root.get(EserviceView_.LAST_REQUEST),
-                        root.get(EserviceView_.RESPONSE_RECEIVED)))),
-            cb.isTrue(compareTimestampInterval));
+    return cb.and(cb.equal(root.get(EserviceView_.STATE), EserviceInteropState.ACTIVE),
+        cb.isTrue(root.get(EserviceView_.PROBING_ENABLED)),
+        cb.or(
+            cb.and(cb.isNull(root.get(EserviceView_.LAST_REQUEST)),
+                cb.isNull(root.get(EserviceView_.RESPONSE_RECEIVED))),
+            cb.and(cb.lessThanOrEqualTo(makeInterval, cb.currentTimestamp()),
+                cb.lessThanOrEqualTo(root.get(EserviceView_.LAST_REQUEST),
+                    root.get(EserviceView_.RESPONSE_RECEIVED)))),
+        cb.isTrue(compareTimestampInterval));
 
-    query.where(predicate);
-    TypedQuery<EserviceContentCriteria> q = entityManager.createQuery(query);
-    List<EserviceContent> pollingActiveEserviceContent =
-        q.getResultList().stream().map(e -> (EserviceContent) e).toList();
-
-    return new PageImpl<>(pollingActiveEserviceContent,
-        PageRequest.of(offset, limit, Sort.by(EserviceView_.ESERVICE_RECORD_ID).ascending()),
-        pollingActiveEserviceContent.size());
   }
+
 }

--- a/src/main/java/it/pagopa/interop/probing/eservice/operations/repository/query/builder/ProducerQueryBuilder.java
+++ b/src/main/java/it/pagopa/interop/probing/eservice/operations/repository/query/builder/ProducerQueryBuilder.java
@@ -28,7 +28,7 @@ public class ProducerQueryBuilder {
     Predicate predicate = cb.like(cb.upper(root.get(Eservice_.PRODUCER_NAME)),
         "%" + producerName.toUpperCase() + "%");
 
-    query.where(predicate);
+    query.where(predicate).orderBy(cb.asc(root.get(Eservice_.PRODUCER_NAME)));
     TypedQuery<Producer> q =
         entityManager.createQuery(query).setFirstResult(offset).setMaxResults(limit);
 

--- a/src/test/java/it/pagopa/interop/probing/eservice/operations/integration/repository/query/builder/EserviceViewQueryBuilderTest.java
+++ b/src/test/java/it/pagopa/interop/probing/eservice/operations/integration/repository/query/builder/EserviceViewQueryBuilderTest.java
@@ -1,5 +1,6 @@
 package it.pagopa.interop.probing.eservice.operations.integration.repository.query.builder;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
@@ -14,10 +15,10 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Repository;
 import it.pagopa.interop.probing.eservice.operations.dtos.EserviceInteropState;
 import it.pagopa.interop.probing.eservice.operations.dtos.EserviceMonitorState;
+import it.pagopa.interop.probing.eservice.operations.dtos.EserviceStatus;
 import it.pagopa.interop.probing.eservice.operations.dtos.EserviceTechnology;
 import it.pagopa.interop.probing.eservice.operations.model.view.EserviceView;
 import it.pagopa.interop.probing.eservice.operations.repository.query.builder.EserviceViewQueryBuilder;
@@ -40,28 +41,49 @@ class EserviceViewQueryBuilderTest {
         .pollingEndTime(OffsetTime.of(23, 59, 0, 0, ZoneOffset.UTC))
         .pollingStartTime(OffsetTime.of(0, 0, 0, 0, ZoneOffset.UTC)).pollingFrequency(5)
         .probingEnabled(true).versionNumber(1).state(EserviceInteropState.ACTIVE)
-        .responseReceived(OffsetDateTime.parse("2023-03-21T00:00:05.995Z"))
-        .lastRequest(OffsetDateTime.parse("2023-03-21T00:00:15.995Z"))
+        .responseReceived(OffsetDateTime.parse("2023-03-21T00:00:15.995Z"))
+        .responseStatus(EserviceStatus.OK)
+        .lastRequest(OffsetDateTime.parse("2023-03-21T00:00:05.995Z"))
         .technology(EserviceTechnology.REST).basePath(new String[] {"base_path_test"})
         .eserviceRecordId(10L).build();
     testEntityManager.persistAndFlush(eserviceView);
   }
 
   @Test
-  @DisplayName("given state n/d, service returns e-service view entity")
+  @DisplayName("given state n/d, service does not find any e-service view entity")
   void testFindAll_whenGivenStateND_ReturnsEserviceEntity() {
-    Page<EserviceView> e = eserviceViewQueryBuilder.findAllWithNDState(1, 0, "e-service1",
+    List<EserviceView> e = eserviceViewQueryBuilder.findAllWithNDState(1, 0, "e-service1",
         "producer1", null, List.of(EserviceMonitorState.N_D), 0);
 
-    assertNotNull(e.getContent(), "e-service object shouldn't be null");
+    assertNotNull(e, "e-service object shouldn't be null");
+    assertEquals(0, e.size(), "no e-service is found with the given state");
+  }
+
+  @Test
+  @DisplayName("no e-service is found with the given state")
+  void testCount_whenGivenStateND_ReturnsEserviceEntity() {
+    Long totalCount = eserviceViewQueryBuilder.getTotalCountWithNDState("e-service1", "producer1",
+        null, List.of(EserviceMonitorState.N_D), 0);
+
+    assertEquals(0, totalCount, "service returns an empty content");
   }
 
   @Test
   @DisplayName("given state active, service returns e-service view entity")
   void testFindAll_whenGivenStateActive_ReturnsEserviceViewEntity() {
-    Page<EserviceView> e = eserviceViewQueryBuilder.findAllWithoutNDState(1, 0, "e-service1",
-        "producer1", null, List.of(EserviceMonitorState.ONLINE), 0);
+    List<EserviceView> e = eserviceViewQueryBuilder.findAllWithoutNDState(1, 0, "e-service Name",
+        "Producer Name", null, List.of(EserviceMonitorState.ONLINE), 3);
 
-    assertNotNull(e.getContent(), "e-service object shouldn't be null");
+    assertNotNull(e, "e-service object shouldn't be null");
+    assertEquals(1, e.size(), "an e-service is found with the given state");
+  }
+
+  @Test
+  @DisplayName("given state active, an e-service is found")
+  void testCount_whenGivenStateOnline_ReturnsEserviceEntity() {
+    Long e = eserviceViewQueryBuilder.getTotalCountWithoutNDState("e-service Name", "Producer Name",
+        1, List.of(EserviceMonitorState.ONLINE), 3);
+
+    assertEquals(1L, e, "service returns a content not empty");
   }
 }

--- a/src/test/java/it/pagopa/interop/probing/eservice/operations/unit/service/ProducerServiceImplTest.java
+++ b/src/test/java/it/pagopa/interop/probing/eservice/operations/unit/service/ProducerServiceImplTest.java
@@ -35,7 +35,7 @@ class ProducerServiceImplTest {
 
   @BeforeEach
   void setup() {
-    producerInput = List.of(Producer.builder().producerName("producer name").build());
+    producerInput = List.of(Producer.builder().producerName(producerNameInput).build());
   }
 
   @Test


### PR DESCRIPTION
The pagination of query results has been fixed. Previously, the results were paginated using the **PageImpl(List<T> content, Pageable pageable, long total)** class. However, the pagination was not functioning correctly and the total number of elements was calculated as follows:
```
this.total = pageable.toOptional()
    .filter(it -> !content.isEmpty())
    .filter(it -> it.getOffset() + it.getPageSize() > total)
    .map(it -> it.getOffset() + content.size())
    .orElse(total);
```
This resulted in an incorrect total element count being outputted.